### PR TITLE
Set extvector flag for vector properties

### DIFF
--- a/compute_allegro.cpp
+++ b/compute_allegro.cpp
@@ -64,6 +64,8 @@ ComputeAllegro<peratom>::ComputeAllegro(LAMMPS *lmp, int narg, char **arg) : Com
                      size_peratom_cols, newton);
   } else {
     vector_flag = 1;
+    //As stated in the README, we assume vector properties are extensive
+    extvector = 1;
     size_vector = std::atoi(arg[4]);
     if (size_vector <= 0) error->all(FLERR, "Incorrect vector length!");
     memory->create(vector, size_vector, "ComputeAllegro:vector");


### PR DESCRIPTION
LAMMPS now enforces that computes, fixes, etc. track whether properties they produce are extensive or intensive via the extscalar/extvector flags.