### PR TITLE
Set extvector for LAMMPS bookkeeping

### DIFF
--- a/compute/compute_allegro.cpp
+++ b/compute/compute_allegro.cpp
@@ -64,6 +64,8 @@ ComputeAllegro<peratom>::ComputeAllegro(LAMMPS *lmp, int narg, char **arg) : Com
                      size_peratom_cols, newton);
   } else {
     vector_flag = 1;
+    //As stated in the README, we assume vector properties are extensive
+    extvector = 1;
     size_vector = std::atoi(arg[4]);
     if (size_vector <= 0) error->all(FLERR, "Incorrect vector length!");
     memory->create(vector, size_vector, "ComputeAllegro:vector");

--- a/tests/test_data/test_repro_allegro.yaml
+++ b/tests/test_data/test_repro_allegro.yaml
@@ -84,15 +84,12 @@ training_module:
     type_names: ${model_type_names}
     r_max: ${cutoff_radius}
     # general model params
-    scalar_embed:
+    radial_chemical_embed:
       _target_: allegro.nn.TwoBodyBesselScalarEmbed
       num_bessels: 8
       bessel_trainable: false
       polynomial_cutoff_p: 6
-      two_body_embedding_dim: 32
-      two_body_mlp_hidden_layers_depth: 0
     l_max: 2
-    parity_setting: o3_full
     num_layers: 3
     num_scalar_features: 64
     num_tensor_features: 32


### PR DESCRIPTION
LAMMPS now enforces that computes, fixes, etc. track whether properties they produce are extensive or intensive via the extscalar/extvector flags.